### PR TITLE
Enrich more than 10 previous transactions

### DIFF
--- a/backend/queues/src/main/java/com/griddynamics/msd365fp/manualreview/queues/service/ItemEnrichmentService.java
+++ b/backend/queues/src/main/java/com/griddynamics/msd365fp/manualreview/queues/service/ItemEnrichmentService.java
@@ -76,9 +76,6 @@ public class ItemEnrichmentService {
     @Setter(onMethod = @__({@Value("${azure.cosmosdb.default-ttl}")}))
     private Duration defaultTtl;
 
-    @Value("${azure.graph-api.previous-transactions-count}")
-    private int previousTransactionsCount;
-
     private final GeodeticCalculator geoCalc = new GeodeticCalculator();
 
 
@@ -427,7 +424,7 @@ public class ItemEnrichmentService {
                         n.getMerchantLocalDate().isAfter(mainPurchase.getMerchantLocalDate().minusDays(7))
                 )
                 .sorted((n1, n2) -> n1.getMerchantLocalDate().isBefore( n2.getMerchantLocalDate())? 1 : -1)
-                .limit(previousTransactionsCount)
+                .limit(historyDepth)
                 .map(n -> modelMapper.map(n, PreviousPurchase.class))
                 .collect(Collectors.toList()));
     }

--- a/backend/queues/src/main/resources/application-int.yml
+++ b/backend/queues/src/main/resources/application-int.yml
@@ -56,7 +56,7 @@ mr:
       enrichment-delay: PT30S
       max-enrichment-delay: PT2M
       max-enrichment-attempts: 10
-      history-depth: 10
+      history-depth: 50
     dictionary-reconciliation-task:
       enabled: true
       delay: PT1M
@@ -90,7 +90,6 @@ azure:
     app-service-principal-url: https://graph.microsoft.com/v1.0/servicePrincipals/${DFP_SP_ID}
     user-photo-url-template: https://graph.microsoft.com/beta/users/#user_id#/photo/$value
     timeout: PT5S
-    previous-transactions-count: 50
     retries: 2
     role-mapping:
       ManualReviewFraudManager: ADMIN_MANAGER

--- a/backend/queues/src/main/resources/application-prod.yml
+++ b/backend/queues/src/main/resources/application-prod.yml
@@ -56,7 +56,7 @@ mr:
       enrichment-delay: PT5M
       max-enrichment-delay: PT15M
       max-enrichment-attempts: 10
-      history-depth: 10
+      history-depth: 50
     dictionary-reconciliation-task:
       enabled: true
       delay: PT1H
@@ -90,7 +90,6 @@ azure:
     app-service-principal-url: https://graph.microsoft.com/v1.0/servicePrincipals/${DFP_SP_ID}
     user-photo-url-template: https://graph.microsoft.com/beta/users/#user_id#/photo/$value
     timeout: PT5S
-    previous-transactions-count: 50
     retries: 2
     role-mapping:
       ManualReviewFraudManager: ADMIN_MANAGER

--- a/backend/queues/src/main/resources/application.yml
+++ b/backend/queues/src/main/resources/application.yml
@@ -60,7 +60,7 @@ mr:
       enrichment-delay: PT30S
       max-enrichment-delay: PT2M
       max-enrichment-attempts: 10
-      history-depth: 10
+      history-depth: 50
     dictionary-reconciliation-task:
       enabled: true
       delay: PT1H
@@ -121,7 +121,6 @@ azure:
     app-service-principal-url: https://graph.microsoft.com/v1.0/servicePrincipals/${DFP_SP_ID}
     user-photo-url-template: https://graph.microsoft.com/beta/users/#user_id#/photo/$value
     timeout: PT5S
-    previous-transactions-count: 50
     retries: 2
     role-mapping:
       ManualReviewFraudManager: ADMIN_MANAGER


### PR DESCRIPTION
Removed previous transactions param. Used historyDepth instead. Bumped historyDepth to be 50.
Before (only 10 transactions were enriched):
![before1](https://user-images.githubusercontent.com/28061748/127712872-66b70bfc-083a-4150-8a7a-836e7d20b39f.PNG)

After:
11 transactions were enriched:
![image](https://user-images.githubusercontent.com/28061748/127712558-f077948a-3f30-45de-954c-6d8ddaa2f1ec.png)
