### PR TITLE
Fix an issue with link-analysys page.

### DIFF
--- a/frontend/src/screens/review-console/item-details/parts/link-analysis/items-list/items-list.tsx
+++ b/frontend/src/screens/review-console/item-details/parts/link-analysis/items-list/items-list.tsx
@@ -113,7 +113,7 @@ export class ItemsList extends Component<ItemsListComponentProps, never> {
             className: `${CN}__cell`,
             columnActionsMode: ColumnActionsMode.disabled,
             onRender: (item: LinkAnalysisItem) => {
-                const itemId = (item as LinkAnalysisMrItem).item.purchase.originalOrderId || '';
+                const itemId = (item as LinkAnalysisMrItem)?.item?.purchase?.originalOrderId || '';
 
                 return (
                     <div className={`${CN}__order-id-cell`}>


### PR DESCRIPTION
Currently LI are blocked because the item bellow is throwing an error and they end up with blank page.
Had a session with Aaron, and we saw the error in his dev tools. (cannot repro it in our system, cause we always have these fields populated).