### PR TITLE
Fix: items could not be selected in link analysis

### DIFF
--- a/frontend/src/data-services/data-transformers/item-transformer/link-analysis/get-link-analysis-dfp-items-transformer.ts
+++ b/frontend/src/data-services/data-transformers/item-transformer/link-analysis/get-link-analysis-dfp-items-transformer.ts
@@ -8,13 +8,24 @@ import {
 } from '../../../api-services/item-api-service/api-models';
 import { DfpItemDto } from '../../../api-services/models/item';
 import { UserBuilder } from '../../../../utility-services';
+import { formatDateStringToJSDate } from '../../../../utils/date/formatters';
 
 export class GetLinkAnalysisDfpItemsTransformer implements DataTransformer {
     constructor(private readonly userBuilder: UserBuilder) {}
 
     mapResponse(getLinkAnalysisDfpItemsResponse: GetLinkAnalysisDfpItemsResponse): LinkAnalysisDfpItem[] {
         return getLinkAnalysisDfpItemsResponse.values
-            .map(linkAnalysisDfpItemDto => this.mapSingleItem(linkAnalysisDfpItemDto));
+            .map(linkAnalysisDfpItemDto => this.mapSingleItem(linkAnalysisDfpItemDto))
+            .sort((prev, next) => {
+                const prevDate = formatDateStringToJSDate(prev.merchantLocalDate);
+                const nextDate = formatDateStringToJSDate(next.merchantLocalDate);
+
+                if (prevDate && nextDate) {
+                    return nextDate.getTime() - prevDate.getTime();
+                }
+
+                return 0;
+            });
     }
 
     private mapSingleItem(linkAnalysisDfpItemDto: DfpItemDto) {

--- a/frontend/src/data-services/data-transformers/item-transformer/link-analysis/get-link-analysis-mr-items-transformer.ts
+++ b/frontend/src/data-services/data-transformers/item-transformer/link-analysis/get-link-analysis-mr-items-transformer.ts
@@ -6,13 +6,24 @@ import { LinkAnalysisMrItem } from '../../../../models/item/link-analysis';
 import { GetLinkAnalysisMrItemsResponse } from '../../../api-services/item-api-service/api-models';
 import { LinkAnalysisMrItemDto } from '../../../api-services/models/item';
 import { UserBuilder } from '../../../../utility-services';
+import { formatDateStringToJSDate } from '../../../../utils/date/formatters';
 
 export class GetLinkAnalysisMrItemsTransformer implements DataTransformer {
     constructor(private readonly userBuilder: UserBuilder) {}
 
     mapResponse(getLinkAnalysisMrItemsResponse: GetLinkAnalysisMrItemsResponse): LinkAnalysisMrItem[] {
         return getLinkAnalysisMrItemsResponse.values
-            .map(linkAnalysisMrItemDto => this.mapSingleItem(linkAnalysisMrItemDto));
+            .map(linkAnalysisMrItemDto => this.mapSingleItem(linkAnalysisMrItemDto))
+            .sort((prev, next) => {
+                const prevDate = formatDateStringToJSDate(prev.item?.purchase?.merchantLocalDate);
+                const nextDate = formatDateStringToJSDate(next.item?.purchase?.merchantLocalDate);
+
+                if (prevDate && nextDate) {
+                    return nextDate.getTime() - prevDate.getTime();
+                }
+
+                return 0;
+            });
     }
 
     private mapSingleItem(linkAnalysisMrItemDto: LinkAnalysisMrItemDto) {

--- a/frontend/src/screens/review-console/item-details/parts/link-analysis/items-list/items-list.tsx
+++ b/frontend/src/screens/review-console/item-details/parts/link-analysis/items-list/items-list.tsx
@@ -29,7 +29,6 @@ import { DEFAULT_LINK_ANALYSIS_ITEMS_PER_PAGE, ITEM_LIST_COLUMN_KEYS } from '../
 import { ITEM_STATUS } from '../../../../../../models/item';
 import { LinkAnalysisDfpItem, LinkAnalysisMrItem } from '../../../../../../models/item/link-analysis';
 import { LinkAnalysisItem } from '../../../../../../view-services';
-import { formatDateStringToJSDate } from '../../../../../../utils/date/formatters';
 
 interface ItemsListComponentProps {
     data: LinkAnalysisItem[];
@@ -329,25 +328,6 @@ export class ItemsList extends Component<ItemsListComponentProps, never> {
             this.selection.setAllSelected(false);
             return this.renderLoader();
         }
-        const sortedData = data
-            .slice()
-            .sort((prev, next) => {
-                const prevX = isMrItem(prev)
-                    ? prev.item?.purchase?.merchantLocalDate
-                    : prev.merchantLocalDate;
-                const nextX = isMrItem(next)
-                    ? next.item?.purchase?.merchantLocalDate
-                    : next.merchantLocalDate;
-                const prevDate = formatDateStringToJSDate(prevX);
-                const nextDate = formatDateStringToJSDate(nextX);
-
-                if (prevDate && nextDate) {
-                    return nextDate.getTime() - prevDate.getTime();
-                }
-
-                return 0;
-            });
-
         const groupsData = groupBy(data, 'item.purchase.originalOrderId');
 
         const groups: IGroup[] = [];
@@ -376,11 +356,11 @@ export class ItemsList extends Component<ItemsListComponentProps, never> {
                         className={cx(CN)}
                         groups={groups}
                         selection={this.selection}
-                        items={sortedData || []}
+                        items={data || []}
                         /* eslint-disable-next-line react/jsx-props-no-spreading */
                         onRenderRow={this.onRenderRow}
                     />
-                    { sortedData.length > 0 && this.renderLoadMoreBtn() }
+                    { data.length > 0 && this.renderLoadMoreBtn() }
                 </>
             );
         }
@@ -392,11 +372,11 @@ export class ItemsList extends Component<ItemsListComponentProps, never> {
                     selectionMode={SelectionMode.none}
                     className={cx(CN)}
                     groups={groups}
-                    items={sortedData || []}
+                    items={data || []}
                     /* eslint-disable-next-line react/jsx-props-no-spreading */
                     onRenderRow={this.onRenderRow}
                 />
-                { sortedData.length > 0 && this.renderLoadMoreBtn() }
+                { data.length > 0 && this.renderLoadMoreBtn() }
             </>
         );
     }


### PR DESCRIPTION
Introduced a bug with the previous item - grouping by original order id in link analysis.
You can still see the issue on https://dev-dfp-mr.azurefd.net/
Before:
![before](https://user-images.githubusercontent.com/28061748/135506826-f72584f8-df05-4dc6-97d0-c5b870d32b00.gif)

After:
![after](https://user-images.githubusercontent.com/28061748/135506910-1c542768-a339-4940-9564-7c202722a36d.gif)

